### PR TITLE
Speedometer5 width

### DIFF
--- a/screens/HomeScreen/Override.css
+++ b/screens/HomeScreen/Override.css
@@ -766,7 +766,7 @@
   position: absolute;
   left: var(--second-right);
   top: 50px;
-  width: 150px;
+  width: 169px;
   background-color: white;
   z-index: 10;
 }


### PR DESCRIPTION
Width of textblock (Speedometer5ExtraContainer1)  should be set like for Speedometer0 on page 1: 169px instead of 150px